### PR TITLE
Added handling logic for expired iterators

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,9 +191,9 @@ DynamoDBStream.prototype._getShardRecords = function (records, shardData, callba
 	this._ddbStreams.getRecords({ ShardIterator: shardData.nextShardIterator }, function (err, result) {
 		if (err) {
 			if (err.code === 'ExpiredIteratorException') {
-      	shardData.nextShardIterator = undefined;
-        return callback();
-      }
+				shardData.nextShardIterator = undefined;
+				return callback();
+			}
 			return callback(err);
 		}
 

--- a/index.js
+++ b/index.js
@@ -192,7 +192,6 @@ DynamoDBStream.prototype._getShardRecords = function (records, shardData, callba
 		if (err) {
 			if (err.code === 'ExpiredIteratorException') {
 				shardData.nextShardIterator = undefined;
-				return callback();
 			}
 			return callback(err);
 		}


### PR DESCRIPTION
This module saves the `nextShardIterator` in a field on a list of shards which are looped over whenever the stream is polled. Under normal circumstances this works great, but in the event of a network outage, eventually that saved `nextShardIterator` will expire (AWS expires it after 15 minutes). When this happens, no matter how many times you poll and execute `fetchStreamState`, it will always throw an error because it never fetches a new iterator. No new records will ever be processed because that error bubbles back up to the top.

The fix is fairly simple, when the expired error happens, I just set the `nextShardIterator` to undefined, which will cause the code to fetch a new iterator (line 169) the next time `fetchStreamState` is called. There's really nothing else you can do at this point since the iterator is expired.