### PR TITLE
Pass batched events back fetchStreamRecords callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ DynamoDBStream.prototype.fetchStreamRecords = function (callback) {
 		setImmediate(_.bind(self._emitRecordEvents, self, records))
 
 		if (callback) {
-			callback()
+			callback(null, records);
 		}
 	})
 }


### PR DESCRIPTION
I have similar use case as described in issue https://github.com/ironSource/node-dynamodb-stream/issues/4 .

I was able to get what I needed by passing the records collected in ``fetchStreamRecords`` its callback. Example:

````javascript
dynamoDBStreams.fetchStreamRecords(function (err, records) {
  execMyLambdaFn({ Records: records });
});
````

This way the ``event`` argument to my AWS Lambda handler is in the correct format such as:

````
{ Records: [ { eventID: '2529aca6-bd7b-416f-b0a1-a611dbafb633',
    eventName: 'INSERT',
    eventVersion: '1.0',
    eventSource: 'aws:dynamodb',
    awsRegion: 'myregion',
    dynamodb: 
     { Keys: { /* ... * },
       NewImage: { /* ... */ },
       SequenceNumber: '000000000000000000020',
       SizeBytes: 133,
       StreamViewType: 'NEW_IMAGE' } } ,
 { eventID: '2529aca6-bd7b-416f-b0a1-a811dbafc823',
    eventName: 'REMOVE',
    eventVersion: '1.0',
    eventSource: 'aws:dynamodb',
    awsRegion: 'myregion',
    dynamodb: 
     { Keys: { /* ... * },
       SequenceNumber: '000000000000000000020',
       SizeBytes: 133,
       StreamViewType: 'NEW_IMAGE' } }] }
````