### PR TITLE
update npm package versions to fix all critical vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "^1.4.2",
     "debug": "^2.2.0",
     "dynamodb-value": "^1.0.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.10",
     "setimmediate": "^1.0.2"
   },
   "author": "Yaniv Kessler",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "aws-sdk": "^2.1.45",
     "chai": "^3.2.0",
-    "mocha": "^2.2.5",
+    "mocha": "^5.2.0",
     "rc": "^1.1.0"
   }
 }


### PR DESCRIPTION
We found 4 vulnerabilities (2 low, 1 high, 1 critical) in 52 scanned dependencies packages.
Including
* [Critical] Command Injection: `growl` package, it is dependency of `mocha`  https://nodesecurity.io/advisories/146
* [High] Regular Expression Denial of Service: `minimatch` is dependency of `mocha`  https://nodesecurity.io/advisories/118

All tests has been passed.
You need review this PR as soon as possible.
