### PR TITLE
Handle non-existent shards

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,8 +147,16 @@ class DynamoDBStream extends EventEmitter {
 			StreamArn: this._streamArn
 		}
 
-		const { ShardIterator } = await this._ddbStreams.getShardIterator(params)
-		shardData.nextShardIterator = ShardIterator
+		try {
+			const { ShardIterator } = await this._ddbStreams.getShardIterator(params)
+			shardData.nextShardIterator = ShardIterator
+		} catch (e) {
+			if (e.name === 'ResourceNotFoundException') {
+				debug('shard %s no longer exists, skipping', shardData.shardId)
+			} else {
+				throw e
+			}
+		}
 	}
 
 	async _getRecords() {
@@ -161,6 +169,10 @@ class DynamoDBStream extends EventEmitter {
 
 	async _getShardRecords(shardData) {
 		debug('_getShardRecords')
+
+		if (!shardData.nextShardIterator) {
+			return []
+		}
 
 		const params = { ShardIterator: shardData.nextShardIterator }
 


### PR DESCRIPTION
Resolves https://github.com/ironSource/node-dynamodb-stream/issues/16. When the `getShardIterator` API call raises a `ResourceNotFoundException` we can simply skip the shard.